### PR TITLE
Guard against NPE when modid or item is null in Condition.verify().

### DIFF
--- a/src/main/java/draylar/maybedata/data/Condition.java
+++ b/src/main/java/draylar/maybedata/data/Condition.java
@@ -15,11 +15,11 @@ public class Condition {
     }
 
     public boolean verify() {
-        if(!modid.isEmpty()) {
+        if(!(modid == null || modid.isEmpty())) {
             return FabricLoader.getInstance().isModLoaded(modid);
         }
 
-        if(!item.isEmpty()) {
+        if(!(item == null || item.isEmpty())) {
             return Registry.ITEM.getIds().contains(new Identifier(item));
         }
 


### PR DESCRIPTION
When testing for item existence instead of loaded mod ID it is tempting to leave out modid in the recipe JSON but that causes an NPE when Condition.verify() checks ```modid.isEmpty()```.  This can be worked around by setting ```"modid": ""``` in the recipe.  I'm proposing to fix it by guarding against null values.